### PR TITLE
Minor fixes to some files

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,6 +22,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
   config.vm.network "forwarded_port", guest: 5000, host: 5000, auto_correct: true
+  config.vm.network "forwarded_port", guest: 4000, host: 4000, auto_correct: true
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ Flask-Migrate
 requests
 flask-discoverer
 httpretty
--e git+https://github.com/adsabs/flask-consulate@8d7e60122cbc73693ac37a5468b9be78bea774a1#egg=flask-consulate
+git+https://github.com/adsabs/flask-consulate@8d7e60122cbc73693ac37a5468b9be78bea774a1#egg=flask-consulate

--- a/sample_application/manage.py
+++ b/sample_application/manage.py
@@ -3,7 +3,7 @@ Example manage.py script, which is responsible for providing a command-line
 interface to application specific tasks, such as managing databases.
 """
 
-from flask.ext.script import Manager
+from flask.ext.script import Manager, Command
 from flask.ext.migrate import Migrate, MigrateCommand
 from models import db
 from app import create_app


### PR DESCRIPTION
1. Vagrantfile: opened port 4000 for when wsgi is run, so as to be seen on localhost
2. requirements.txt: removed -e, 'edit' flag, so that flask-consul is installed in local/lib rather that in ./src/
3. manage.py: missing import, which would mean it would not run